### PR TITLE
Add go modules support

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -2,8 +2,9 @@ package ast
 
 import (
 	"fmt"
-	"knox/token"
 	"strings"
+
+	"github.com/AZHenley/knox/token"
 )
 
 // NodeType is a string.

--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -2,9 +2,10 @@ package builtin
 
 import (
 	"io/ioutil"
-	"knox/ast"
-	"knox/lexer"
-	"knox/parser"
+
+	"github.com/AZHenley/knox/ast"
+	"github.com/AZHenley/knox/lexer"
+	"github.com/AZHenley/knox/parser"
 )
 
 // import "knox/ast"

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -2,8 +2,9 @@ package emitter
 
 import (
 	"fmt"
-	"knox/ast"
 	"strings"
+
+	"github.com/AZHenley/knox/ast"
 )
 
 var level = 0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/AZHenley/knox
+
+go 1.13

--- a/knox.go
+++ b/knox.go
@@ -4,17 +4,18 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"knox/ast"
-	"knox/builtin"
-	"knox/emitter"
-	"knox/lexer"
-	"knox/parser"
-	"knox/typechecker"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"time"
+
+	"github.com/AZHenley/knox/ast"
+	"github.com/AZHenley/knox/builtin"
+	"github.com/AZHenley/knox/emitter"
+	"github.com/AZHenley/knox/lexer"
+	"github.com/AZHenley/knox/parser"
+	"github.com/AZHenley/knox/typechecker"
 )
 
 func main() {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -4,7 +4,8 @@ package lexer
 
 import (
 	"fmt"
-	"knox/token"
+
+	"github.com/AZHenley/knox/token"
 )
 
 // Lexer object.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -2,10 +2,10 @@ package parser
 
 import (
 	"fmt"
-	"knox/ast"
-	"knox/lexer"
 
-	"knox/token"
+	"github.com/AZHenley/knox/ast"
+	"github.com/AZHenley/knox/lexer"
+	"github.com/AZHenley/knox/token"
 )
 
 // Parser object.

--- a/typechecker/typechecker.go
+++ b/typechecker/typechecker.go
@@ -2,9 +2,10 @@ package typechecker
 
 import (
 	"fmt"
-	"knox/ast"
-	"knox/lexer"
-	"knox/token"
+
+	"github.com/AZHenley/knox/ast"
+	"github.com/AZHenley/knox/lexer"
+	"github.com/AZHenley/knox/token"
 )
 
 var prim primitives // Object holding the primitive types.


### PR DESCRIPTION
Adds module support so that packages can be used outside of GOTPATH.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Wasn't sure if this is something you wanted to support (i.e. no issue open for it), but was looking into some other parts of the codebase and added this for my own local dev, so I thought I would push upstream as well. Feel free to close if you don't find this useful :+1: 